### PR TITLE
Removing <b> in favour of _

### DIFF
--- a/css/stylesheet.css
+++ b/css/stylesheet.css
@@ -266,8 +266,9 @@ p {
    margin: 0px;
 }
 
-b {
+em {
   font-family: 'hk_groteskbold';
+  font-style: unset;
 }
 
 .remark-slide {

--- a/index.html
+++ b/index.html
@@ -11,19 +11,19 @@
 
 class: middle, title-slide
 
-# <b>CDS Team meeting, Nov 27th</b> Introducing Remark.js
+# _CDS Team meeting, Nov 27th_ Introducing Remark.js
 
 ---
 
 class:left, middle
 
-# <b>This is an example of a text slide. Try to keep it short and remember to use simple language.</b>
+# _This is an example of a text slide. Try to keep it short and remember to use simple language._
 
 ---
 
 class: center, image-slide
 
-# <b> This is ex. of an image-slide</b>
+# _This is ex. of an image-slide_
 
 ![Image example 1](images/projects1.png)
 
@@ -31,7 +31,7 @@ class: center, image-slide
 
 class: center, image-slide
 
-# <b> This is ex. of an image-slide</b>
+# _This is ex. of an image-slide_
 
 ![Image example 2](images/projects2.png)
 
@@ -39,7 +39,7 @@ class: center, image-slide
 
 class: center, image-slide
 
-# <b> This is ex. of an image-slide</b>
+# _This is ex. of an image-slide_
 
 ![Image example 3](images/projects3.png)
 
@@ -47,26 +47,26 @@ class: center, image-slide
 
 class: left, middle, quote-slide
 
-# <b>This is an example of a quote slide</b>
+# _This is an example of a quote slide_
 
-### The Government of Canada has an opportunity—and a responsibility—to deliver world-class services to Canadians. <b>This will require disruption as we make the switch, both technically and culturally, to agile digital delivery models. To accelerate these efforts, I am excited to announce the launch of the Canadian Digital Service (CDS)</b> to modernize the way the Government of Canada designs and delivers digital services. CDS will be a partner to departments in delivering measurably improved services. <b>We are rethinking the service design and delivery process</b> from the user’s perspective, and engaging users every step of the way. -- the Honourable Scott Brison
+### The Government of Canada has an opportunity—and a responsibility—to deliver world-class services to Canadians. _This will require disruption as we make the switch, both technically and culturally, to agile digital delivery models. To accelerate these efforts, I am excited to announce the launch of the Canadian Digital Service (CDS)_ to modernize the way the Government of Canada designs and delivers digital services. CDS will be a partner to departments in delivering measurably improved services. _We are rethinking the service design and delivery process_ from the user’s perspective, and engaging users every step of the way. -- the Honourable Scott Brison
 
 
 ---
 
 class:left, middle, section-slide
 
-# <b> This is an ex. of a section header </b> <br> ...and subheader
+# _ This is an ex. of a section header _ <br> ...and subheader
 
 ---
 
 class:left, middle
 
-# <b> This is an examle of an <br> ordered list</b>
+# _ This is an examle of an <br> ordered list_
 
-* <b> 1) List item 1: </b> stuff 
-* <b> 2) List item 2: </b> more stuff
-* <b> 3) List item 3: </b> even more stuff
+* _ 1) List item 1: _ stuff 
+* _ 2) List item 2: _ more stuff
+* _ 3) List item 3: _ even more stuff
 
 ---
 
@@ -76,28 +76,28 @@ class:left, middle
 
 .iconLeft[![Left Icon](images/leftIcon.svg)]
 
-# <b>This is an example of a slide <br> with a supporting icon. Try <br> to keep it to 3 lines.</b>
+# _This is an example of a slide <br> with a supporting icon. Try <br> to keep it to 3 lines._
 
 
 ---
 
 class: left, middle
 
-# <b> H1 Header + H3 supporting text </b> <br> 
+# _H1 Header + H3 supporting text_
 
-### This is an example of a text only slide. Although some people might require more space, it is encouraged to keep it brief and use the 3 line slide template. Keep the text bold  with the < b > tag, line break when necessary < br > and try to stay between 5 or 6 lines.
+### This is an example of a text only slide. Although some people might require more space, it is encouraged to keep it brief and use the 3 line slide template. Keep the text bold by surrounding it with underscores, line break when necessary < br > and try to stay between 5 or 6 lines.
 
 ---
 
 class:left, middle, section-slide
 
-# <b> Coding Example: </b> <br> Title for Coding section 
+# _ Coding Example: _ <br> Title for Coding section 
 
 ---
 
 class: center
 
-# <b> Any Questions?</b>
+# _Any Questions?_
 
 .contactImages[![Contact Images](images/contact.png)]
 


### PR DESCRIPTION
Underscores are the way to go for emphasis in markdown. They generate
test wrapped in <em> tags rather than <b> tags though.